### PR TITLE
Entry/Item level attributes

### DIFF
--- a/lib/simple-rss.rb
+++ b/lib/simple-rss.rb
@@ -119,7 +119,15 @@ class SimpleRSS
   				elsif match[3] =~ %r{<(rss:|atom:)?#{tag}(.*?)#{attrib}=['"](.*?)['"](.*?)/\s*>}mi
   				  nil
   				end
-  				item[clean_tag("#{tag}_#{attrib}")] = clean_content(tag, attrib, $3) if $3
+  				
+  				# MM2: Account for attributes on the item/entry tag
+  				if tag == "item" || tag == "entry"
+  				  if match[2] =~ /#{attrib}=['"](.*)['"]/
+  				    item[clean_tag("#{tag}_#{attrib}")] = clean_content(tag, attrib, $1) 
+  				  end
+  				else  				
+  				  item[clean_tag("#{tag}_#{attrib}")] = clean_content(tag, attrib, $3) if $3
+  				end
 		    else
   				if match[3] =~ %r{<(rss:|atom:)?#{tag}(.*?)>(.*?)</(rss:|atom:)?#{tag}>}mi
   					nil

--- a/test/base/entry_attributes_test.rb
+++ b/test/base/entry_attributes_test.rb
@@ -1,0 +1,27 @@
+require File.dirname(__FILE__) + '/../test_helper'
+class EntryAttributesTest < Test::Unit::TestCase
+	def setup
+	  SimpleRSS.item_tags << :'entry#gr:crawl-timestamp-msec'
+	  
+    @rss09 = SimpleRSS.parse open(File.dirname(__FILE__) + '/../data/rss09.rdf')
+		@rss20 = SimpleRSS.parse open(File.dirname(__FILE__) + '/../data/rss20.xml')
+		@media_rss = SimpleRSS.parse open(File.dirname(__FILE__) + '/../data/media_rss.xml')
+		@atom = SimpleRSS.parse open(File.dirname(__FILE__) + '/../data/atom.xml')
+	end
+		
+  def test_rss09
+    assert_equal "1291841305234", @rss09.items.first[:'entry_gr_crawl-timestamp-msec']
+  end
+  
+  def test_media_rss
+    assert_equal "1291841305234", @media_rss.items.first[:'entry_gr_crawl-timestamp-msec']
+  end
+  
+  def test_rss20
+    assert_equal "1291841305234", @rss20.items.first[:'entry_gr_crawl-timestamp-msec']
+  end
+  
+  def test_atom
+    assert_equal "1291841305234", @atom.entries.first[:'entry_gr_crawl-timestamp-msec']
+  end
+end

--- a/test/data/atom.xml
+++ b/test/data/atom.xml
@@ -15,7 +15,7 @@
   <generator uri="http://www.example.com/" version="1.0">
     Example Toolkit
   </generator>
-  <entry>
+  <entry gr:crawl-timestamp-msec="1291841305234">
     <title>Atom draft-07 snapshot</title>
     <link rel="alternate" type="text/html" 
      href="http://example.org/2005/04/02/atom"/>

--- a/test/data/media_rss.xml
+++ b/test/data/media_rss.xml
@@ -19,7 +19,7 @@
 			<link>http://www.flickr.com/photos/herval/</link>
 		</image>
 
-		<item>
+		<item gr:crawl-timestamp-msec="1291841305234">
 			<title>Woof?</title>
 			<link>http://www.flickr.com/photos/herval/4671960608/</link>
 			<description>			&lt;p&gt;&lt;a href=&quot;http://www.flickr.com/people/herval/&quot;&gt;herval&lt;/a&gt; posted a photo:&lt;/p&gt;

--- a/test/data/rss09.rdf
+++ b/test/data/rss09.rdf
@@ -18,7 +18,7 @@ xmlns="http://my.netscape.com/rdf/simple/0.9/">
 <link>http://slashdot.org/</link>
 </image>
 
-<item>
+<item gr:crawl-timestamp-msec="1291841305234">
 <title>JBoss - A Developer's Notebook</title>
 <link>http://books.slashdot.org/article.pl?sid=05/08/29/1319236&amp;from=rss</link>
 <dc:date>2005-09-09T02:52:31-07:00</dc:date>

--- a/test/data/rss20.xml
+++ b/test/data/rss20.xml
@@ -12,7 +12,7 @@
     <language>en</language>
     <atom:link xmlns:atom="http://purl.org/atom/ns#" rel="self" href="http://feeds.feedburner.com/rufytech" type="application/rss+xml" />
     <feedburner:browserFriendly>This is an XML content feed. It is intended to be viewed in a newsreader or syndicated to another site.</feedburner:browserFriendly>
-    <item>
+    <item gr:crawl-timestamp-msec="1291841305234">
       <title>some_string.starts_with? “Foo” || some_string.ends_with? “bar.”</title>
       <link>http://feeds.feedburner.com/rufytech?m=68</link>
       <comments>http://tech.rufy.com/entry/82#comments</comments>


### PR DESCRIPTION
I needed the ability to grab attributes off the entry or item tag...and as far as I could tell there isn't currently a way to do this. I've added the change needed and tests behind it. (Let me know if you'd like me to move my tests from their own file back into base_test.)

I'm not sure if such a thing is needed by anybody else...or if it's even in spec for atom/rss, but I'm aggregating some Google Reader Shared feeds, and they have them and I need them. (Example: http://www.google.com/reader/public/atom/user/13184750814515218749/state/com.google/broadcast)

Tested on Ruby 1.8.7p174. Thx.
