### PR TITLE
Fix regexp warning on UTF-8 characters

### DIFF
--- a/lib/simple-rss.rb
+++ b/lib/simple-rss.rb
@@ -153,9 +153,9 @@ class SimpleRSS
 	
   def unescape(content)
   	if content.force_encoding("binary") =~ /([^-_.!~*'()a-zA-Z\d;\/?:@&=+$,\[\]]%)/n then
-  		CGI.unescape(content).gsub(/(<!\[CDATA\[|\]\]>)/u,'').strip
+  		CGI.unescape(content).gsub(/(<!\[CDATA\[|\]\]>)/,'').strip
   	else
-  		content.gsub(/(<!\[CDATA\[|\]\]>)/u,'').strip
+  		content.gsub(/(<!\[CDATA\[|\]\]>)/,'').strip
   	end
   end
 end


### PR DESCRIPTION
By `String#force_encoding("binary")` in the `unescape()` method, it's easier to avoid the regexp warning:

```
./gems/simple-rss-ef0d5db568fa/lib/simple-rss.rb:155:
    warning: regexp match /.../n against to UTF-8 string
```

Using this fix today, seems to work all right. My test case is to watch a private RSS feed of an organization on GitHub, and marvel at the error's absence. I'm doing something trivial like:

```
uri = "https://github.com/organizations/%s/%s.private.atom?token=%s"
@rss = SimpleRSS.parse(open(uri))
```

against rapid7/metasploit-framwork (with my RSS token)
