### PR TITLE
Fix README name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ desc "Create documentation"
 Rake::RDocTask.new("doc") { |rdoc|
   rdoc.title = "Simple RSS - A Flexible RSS and Atom reader for Ruby"
   rdoc.rdoc_dir = 'html'
-  rdoc.rdoc_files.include('README')
+  rdoc.rdoc_files.include('README.markdown')
   rdoc.rdoc_files.include('lib/*.rb')
 }
 


### PR DESCRIPTION
0e2ce64 did not update the name of the README file in Rakefile, this causes 'rake doc' to fail.

```
$ rake doc
rake aborted!
Don't know how to build task 'README'

Tasks: TOP => doc => html/index.html
(See full trace by running task with --trace)
```
