### PR TITLE
remove ruby forge (no longer exists)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,11 @@
-require 'rubygems'
 require 'bundler/setup'
 require 'rake'
 require 'rake/testtask'
 require 'rdoc/task'
 require 'rubygems/package_task'
-require 'rake/contrib/rubyforgepublisher'
 require './lib/simple-rss'
 
 PKG_VERSION = SimpleRSS::VERSION
-PKG_NAME = "simple-rss"
-PKG_FILE_NAME = "#{PKG_NAME}-#{PKG_VERSION}"
-RUBY_FORGE_PROJECT = "simple-rss"
-RUBY_FORGE_USER = ENV['RUBY_FORGE_USER'] || "cardmagic"
-RELEASE_NAME = "#{PKG_NAME}-#{PKG_VERSION}"
-
 PKG_FILES = FileList[
     "lib/*", "bin/*", "test/**/*", "[A-Z]*", "Rakefile", "html/**/*"
 ]
@@ -89,125 +81,4 @@ task :stats do
     ["Library", "lib"],
     ["Units", "test"]
   ).to_s
-end
-
-desc "Publish new documentation"
-task :publish do
-    Rake::RubyForgePublisher.new('simple-rss', 'cardmagic').upload
-end
-
-
-desc "Publish the release files to RubyForge."
-task :upload => [:package] do
-  files = ["gem", "tar.gz", "zip"].map { |ext| "pkg/#{PKG_FILE_NAME}.#{ext}" }
-
-  if RUBY_FORGE_PROJECT then
-      require 'net/http'
-      require 'open-uri'
-
-      project_uri = "http://rubyforge.org/projects/#{RUBY_FORGE_PROJECT}/"
-      project_data = open(project_uri) { |data| data.read }
-      group_id = project_data[/[?&]group_id=(\d+)/, 1]
-      raise "Couldn't get group id" unless group_id
-
-      # This echos password to shell which is a bit sucky
-      if ENV["RUBY_FORGE_PASSWORD"]
-          password = ENV["RUBY_FORGE_PASSWORD"]
-      else
-          print "#{RUBY_FORGE_USER}@rubyforge.org's password: "
-          password = STDIN.gets.chomp
-      end
-
-      login_response = Net::HTTP.start("rubyforge.org", 80) do |http|
-          data = [
-              "login=1",
-              "form_loginname=#{RUBY_FORGE_USER}",
-              "form_pw=#{password}"
-          ].join("&")
-          http.post("/account/login.php", data)
-      end
-
-      cookie = login_response["set-cookie"]
-      raise "Login failed" unless cookie
-      headers = { "Cookie" => cookie }
-
-      release_uri = "http://rubyforge.org/frs/admin/?group_id=#{group_id}"
-      release_data = open(release_uri, headers) { |data| data.read }
-      package_id = release_data[/[?&]package_id=(\d+)/, 1]
-      raise "Couldn't get package id" unless package_id
-
-      first_file = true
-      release_id = ""
-
-      files.each do |filename|
-          basename  = File.basename(filename)
-          file_ext  = File.extname(filename)
-          file_data = File.open(filename, "rb") { |file| file.read }
-
-          puts "Releasing #{basename}..."
-
-          release_response = Net::HTTP.start("rubyforge.org", 80) do |http|
-              release_date = Time.now.strftime("%Y-%m-%d %H:%M")
-              type_map = {
-                  ".zip"    => "3000",
-                  ".tgz"    => "3110",
-                  ".gz"     => "3110",
-                  ".gem"    => "1400"
-              }; type_map.default = "9999"
-              type = type_map[file_ext]
-              boundary = "rubyqMY6QN9bp6e4kS21H4y0zxcvoor"
-
-              query_hash = if first_file then
-                {
-                  "group_id" => group_id,
-                  "package_id" => package_id,
-                  "release_name" => RELEASE_NAME,
-                  "release_date" => release_date,
-                  "type_id" => type,
-                  "processor_id" => "8000", # Any
-                  "release_notes" => "",
-                  "release_changes" => "",
-                  "preformatted" => "1",
-                  "submit" => "1"
-                }
-              else
-                {
-                  "group_id" => group_id,
-                  "release_id" => release_id,
-                  "package_id" => package_id,
-                  "step2" => "1",
-                  "type_id" => type,
-                  "processor_id" => "8000", # Any
-                  "submit" => "Add This File"
-                }
-              end
-
-              query = "?" + query_hash.map do |(name, value)|
-                  [name, URI.encode(value)].join("=")
-              end.join("&")
-
-              data = [
-                  "--" + boundary,
-                  "Content-Disposition: form-data; name=\"userfile\"; filename=\"#{basename}\"",
-                  "Content-Type: application/octet-stream",
-                  "Content-Transfer-Encoding: binary",
-                  "", file_data, ""
-                  ].join("\x0D\x0A")
-
-              release_headers = headers.merge(
-                  "Content-Type" => "multipart/form-data; boundary=#{boundary}"
-              )
-
-              target = first_file ? "/frs/admin/qrs.php" : "/frs/admin/editrelease.php"
-              http.post(target + query, data, release_headers)
-          end
-
-          if first_file then
-              release_id = release_response.body[/release_id=(\d+)/, 1]
-              raise("Couldn't get release id") unless release_id
-          end
-
-          first_file = false
-      end
-  end
 end

--- a/install.rb
+++ b/install.rb
@@ -22,15 +22,7 @@ makedirs = %w{ shipping }
 makedirs.each {|f| File::makedirs(File.join($sitedir, *f.split(/\//)))}
 
 Dir.chdir("lib")
-begin
-	require 'rubygems'
-	require 'rake'
-rescue LoadError
-	puts
-	puts "Please install Gem and Rake from http://rubyforge.org/projects/rubygems and http://rubyforge.org/projects/rake"
-	puts
-	exit(-1)
-end
+require 'rake'
 
 files = FileList["**/*"]
 

--- a/simple-rss.gemspec
+++ b/simple-rss.gemspec
@@ -10,5 +10,4 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.authors = ["Lucas Carlson"]
   s.files = ["install.rb", "lib", "lib/simple-rss.rb", "LICENSE", "Rakefile", "README.markdown", "simple-rss.gemspec", "test", "test/base", "test/base/base_test.rb", "test/data", "test/data/atom.xml", "test/data/not-rss.xml", "test/data/rss09.rdf", "test/data/rss20.xml", "test/test_helper.rb"]
-  s.rubyforge_project = 'simple-rss'
 end


### PR DESCRIPTION
This removes rubyforge specific code

Build probably won't pass since the .travis.yml needs some changes (see previous PR)

After you merge that, I will rebase to show this passes in 2.2.0
