### PR TITLE
Remove use of deprecated RubyGems #has_rdoc method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,10 +66,6 @@ spec = Gem::Specification.new do |s|
 
   s.require_path = 'lib'
 
-  #### Documentation and testing.
-
-  s.has_rdoc = true
-
   #### Author and project details.
 
   s.author = "Lucas Carlson"

--- a/simple-rss.gemspec
+++ b/simple-rss.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.email = "lucas@rufy.com"
   s.homepage = "http://github.com/cardmagic/simple-rss"
   s.description = "A simple, flexible, extensible, and liberal RSS and Atom reader for Ruby. It is designed to be backwards compatible with the standard RSS parser, but will never do RSS generation."
-  s.has_rdoc = true
   s.authors = ["Lucas Carlson"]
   s.files = ["install.rb", "lib", "lib/simple-rss.rb", "LICENSE", "Rakefile", "README.markdown", "simple-rss.gemspec", "test", "test/base", "test/base/base_test.rb", "test/data", "test/data/atom.xml", "test/data/not-rss.xml", "test/data/rss09.rdf", "test/data/rss20.xml", "test/test_helper.rb"]
   s.rubyforge_project = 'simple-rss'


### PR DESCRIPTION
This is not mine,

I've cherry-picked one from someone else (from 2011):
Thanks,
Keenan

---

As of RubyGems 1.7.0, the #has_rdoc= method is deprecated:

  http://blog.segment7.net/2011/04/01/rubygems-1-7-0

Prior to this commit, requiring the simple-rss gem or running rake for
the simple-rss gem would produce the following warning:

  NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It
  will be removed on or after 2011-10-01.
