### PR TITLE
feat: add array_tags option to collect multiple values

### DIFF
--- a/test/base/array_tags_test.rb
+++ b/test/base/array_tags_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ArrayTagsTest < Test::Unit::TestCase
+  def setup
+    @rss20 = SimpleRSS.parse(
+      open(File.dirname(__FILE__) + "/../data/rss20.xml"),
+      array_tags: [:category]
+    )
+    @rss20_no_array = SimpleRSS.parse(
+      open(File.dirname(__FILE__) + "/../data/rss20.xml")
+    )
+  end
+
+  def test_array_tag_returns_array
+    assert_kind_of Array, @rss20.items.first.category
+  end
+
+  def test_array_tag_contains_all_values
+    categories = @rss20.items.first.category
+    assert_equal 2, categories.size
+    assert_includes categories, "Programming"
+    assert_includes categories, "Ruby"
+  end
+
+  def test_single_value_still_returns_array
+    # Item with only one category should still return an array
+    categories = @rss20.items[2].category
+    assert_kind_of Array, categories
+    assert_equal 1, categories.size
+    assert_equal ["General"], categories
+  end
+
+  def test_without_array_tags_returns_string
+    # Default behavior should return just the first/last match as a string
+    assert_kind_of String, @rss20_no_array.items.first.category
+  end
+end


### PR DESCRIPTION
## Summary

Adds an `array_tags` option that allows collecting all values for repeated tags into an array, instead of just returning the first/last match.

## Usage

```ruby
rss = SimpleRSS.parse(feed, array_tags: [:category])
rss.items.first.category  # => ["Programming", "Ruby"]
```

## Problem

Currently, when a feed has multiple instances of the same tag:

```xml
<item>
  <category>Programming</category>
  <category>Ruby</category>
</item>
```

Only one value is captured. This feature allows capturing all values.

## Implementation

- Added `array_tag?` helper method to check if a tag should return an array
- Modified `parse_simple_tag` to use `scan` for array tags
- Works with any simple tag (not `#attr` or `+rel` variants)

## Test plan

- [x] Array tags return arrays with all values
- [x] Single values still return as single-element arrays
- [x] Non-array tags continue to return strings (backwards compatible)
- [x] All existing tests pass
- [x] RuboCop: no offenses
- [x] Steep type check: no errors

Closes #34