### PR TITLE
feat: support attributes on channel/feed tags

### DIFF
--- a/test/base/feed_attributes_test.rb
+++ b/test/base/feed_attributes_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class FeedAttributesTest < Test::Unit::TestCase
+  def setup
+    # Add feed attribute tags before parsing
+    SimpleRSS.feed_tags << :"channel#custom:version"
+    SimpleRSS.feed_tags << :"feed#app:id"
+
+    @rss20 = SimpleRSS.parse open(File.dirname(__FILE__) + "/../data/rss20_with_channel_attrs.xml")
+    @atom = SimpleRSS.parse open(File.dirname(__FILE__) + "/../data/atom_with_feed_attrs.xml")
+  end
+
+  def teardown
+    # Clean up added tags
+    SimpleRSS.feed_tags.delete(:"channel#custom:version")
+    SimpleRSS.feed_tags.delete(:"feed#app:id")
+  end
+
+  def test_rss20_channel_attribute
+    assert_equal "2.0", @rss20.channel_custom_version
+  end
+
+  def test_atom_feed_attribute
+    assert_equal "12345", @atom.feed_app_id
+  end
+end

--- a/test/data/atom_with_feed_attrs.xml
+++ b/test/data/atom_with_feed_attrs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://example.org/app" app:id="12345">
+  <title type="text">Test Feed</title>
+  <updated>2005-07-31T12:29:29Z</updated>
+  <id>tag:example.org,2003:3</id>
+  <link rel="alternate" type="text/html" href="http://example.org/"/>
+  <entry>
+    <title>Test Entry</title>
+    <link rel="alternate" type="text/html" href="http://example.org/entry/1"/>
+    <id>tag:example.org,2003:3.2397</id>
+    <updated>2005-07-31T12:29:29Z</updated>
+  </entry>
+</feed>

--- a/test/data/rss20_with_channel_attrs.xml
+++ b/test/data/rss20_with_channel_attrs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:custom="http://example.org/custom">
+  <channel custom:version="2.0">
+    <title>Test RSS Feed</title>
+    <link>http://example.org</link>
+    <description>A test feed with channel attributes</description>
+    <item>
+      <title>Test Item</title>
+      <link>http://example.org/item/1</link>
+      <description>This is a test item</description>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

Extends the `tag#attr` syntax to work with `channel` and `feed` tags, allowing extraction of attributes directly from the channel/feed element itself.

## Usage

```ruby
SimpleRSS.feed_tags << :"channel#custom:version"
rss = SimpleRSS.parse(feed)
rss.channel_custom_version  # => "2.0"
```

## Use Case

Some feeds include custom attributes on the channel/feed tag:

```xml
<channel xmlns:custom="http://example.org" custom:version="2.0">
  <title>My Feed</title>
  ...
</channel>
```

This was previously not accessible. Now it can be extracted with:

```ruby
SimpleRSS.feed_tags << :"channel#custom:version"
```

## Implementation

- Captures channel/feed tag attributes during initial parsing
- Added `parse_feed_attr_tag` method to handle `channel#attr` and `feed#attr` syntax
- Creates instance variables and attr_readers like other feed tags

## Test plan

- [x] RSS channel attributes work (`channel#attr`)
- [x] Atom feed attributes work (`feed#attr`)
- [x] All existing tests pass (16 tests, 59 assertions)
- [x] RuboCop: no offenses
- [x] Steep type check: no errors

## Background

Originally requested by @poprygun in #7:
> Any chance to add same functionality on feed level in addition to item level?

Closes #37