### PR TITLE
fix: skip empty/blank tags to prevent regex hang

### DIFF
--- a/lib/simple-rss.rb
+++ b/lib/simple-rss.rb
@@ -108,6 +108,8 @@ class SimpleRSS
     end
 
     @@feed_tags.each do |tag|
+      next if tag.to_s.strip.empty?
+
       tag_str = tag.to_s
 
       # Handle channel#attr or feed#attr syntax
@@ -137,6 +139,8 @@ class SimpleRSS
     @source.scan(%r{<(rss:|atom:)?(item|entry)([\s][^>]*)?>(.*?)</(rss:|atom:)?(item|entry)>}mi) do |match|
       item = {} #: Hash[Symbol, untyped]
       @@item_tags.each do |tag|
+        next if tag.to_s.strip.empty?
+
         parse_item_tag(item, tag, match[3], match[2])
       end
       item.define_singleton_method(:method_missing) { |name, *| self[name] }

--- a/test/base/empty_tag_test.rb
+++ b/test/base/empty_tag_test.rb
@@ -1,0 +1,56 @@
+require_relative "../test_helper"
+require "timeout"
+
+class EmptyTagTest < Test::Unit::TestCase
+  def setup
+    @rss20 = SimpleRSS.parse(open(File.dirname(__FILE__) + "/../data/rss20.xml"))
+  end
+
+  def test_empty_item_tag_does_not_hang
+    # Reproduces issue #16: 100% cpu and hanging process on blank item tag
+    # Adding an empty tag should not cause regex catastrophic backtracking
+    original_tags = SimpleRSS.item_tags.dup
+
+    begin
+      SimpleRSS.item_tags << :""
+
+      # This should complete quickly, not hang
+      Timeout.timeout(5) do
+        rss = SimpleRSS.parse(open(File.dirname(__FILE__) + "/../data/rss20.xml"))
+        assert_not_nil rss.items
+      end
+    ensure
+      SimpleRSS.item_tags.replace(original_tags)
+    end
+  end
+
+  def test_blank_item_tag_does_not_hang
+    original_tags = SimpleRSS.item_tags.dup
+
+    begin
+      SimpleRSS.item_tags << :"   "
+
+      Timeout.timeout(5) do
+        rss = SimpleRSS.parse(open(File.dirname(__FILE__) + "/../data/rss20.xml"))
+        assert_not_nil rss.items
+      end
+    ensure
+      SimpleRSS.item_tags.replace(original_tags)
+    end
+  end
+
+  def test_empty_feed_tag_does_not_hang
+    original_tags = SimpleRSS.feed_tags.dup
+
+    begin
+      SimpleRSS.feed_tags << :""
+
+      Timeout.timeout(5) do
+        rss = SimpleRSS.parse(open(File.dirname(__FILE__) + "/../data/rss20.xml"))
+        assert_not_nil rss.channel
+      end
+    ensure
+      SimpleRSS.feed_tags.replace(original_tags)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Skip empty/blank tags with guard clauses to prevent regex catastrophic backtracking
- Empty tags like `:"" ` would create patterns like `<(rss:|atom:)?(.*?)>` causing 100% CPU and process hang

## Test plan
- [x] Added `test/base/empty_tag_test.rb` with 3 tests for empty/blank tags
- [x] All 19 tests pass

Fixes #16