### PR TITLE
fix: normalize all strings to UTF-8 encoding

### DIFF
--- a/lib/simple-rss.rb
+++ b/lib/simple-rss.rb
@@ -264,10 +264,10 @@ class SimpleRSS
   # @rbs (String) -> String
   def unescape(content)
     result = if content =~ %r{([^-_.!~*'()a-zA-Z\d;/?:@&=+$,\[\]]%)}
-      CGI.unescape(content)
-    else
-      content
-    end.gsub(/(<!\[CDATA\[|\]\]>)/, "").strip
+               CGI.unescape(content)
+             else
+               content
+             end.gsub(/(<!\[CDATA\[|\]\]>)/, "").strip
 
     result.encode(Encoding::UTF_8)
   end

--- a/test/base/encoding_test.rb
+++ b/test/base/encoding_test.rb
@@ -24,12 +24,12 @@ class EncodingTest < Test::Unit::TestCase
 
     assert_equal Encoding::UTF_8, rss.title.encoding
     # Verify UTF-8 characters are preserved
-    assert rss.items.any? { |item| item.title && item.title.encoding == Encoding::UTF_8 }
+    assert(rss.items.any? { |item| item.title && item.title.encoding == Encoding::UTF_8 })
   end
 
   def test_ascii_8bit_source_normalized_to_utf8
     # Issue #28: when source is ASCII-8BIT, output should still be UTF-8
-    xml = <<~XML.b  # .b forces ASCII-8BIT encoding
+    xml = <<~XML.b # .b forces ASCII-8BIT encoding
       <?xml version="1.0"?>
       <rss version="2.0">
         <channel>
@@ -81,7 +81,7 @@ class EncodingTest < Test::Unit::TestCase
     rss_without = SimpleRSS.parse(xml_without_percent)
 
     assert_equal rss_with.title.encoding, rss_without.title.encoding,
-      "Encoding should be consistent regardless of '%' in content"
+                 "Encoding should be consistent regardless of '%' in content"
     assert_equal Encoding::UTF_8, rss_without.title.encoding
   end
 end


### PR DESCRIPTION
## Summary
- Normalize all output strings to UTF-8 encoding
- Previously, `CGI.unescape` returned UTF-8 but strings without `%` retained ASCII-8BIT encoding

## Test plan
- [x] Added `test/base/encoding_test.rb` with 5 tests for encoding consistency
- [x] All 21 tests pass

Fixes #28